### PR TITLE
Make coffee-script a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/killercup/react-prop-schema",
   "dependencies": {
-    "coffee-script": "^1.8.0",
     "envify": "^3.0.0",
     "lodash": "^2.4.1",
     "faker": "^2.0.1",
@@ -39,6 +38,7 @@
     "browserify": "^6.1.0",
     "coffeeify": "^0.7.0",
     "coffeelint": "^1.6.0",
+    "coffee-script": "^1.8.0",
     "envify": "^3.0.0",
     "gulp": "^3.8.8",
     "gulp-coffee": "^2.2.0",


### PR DESCRIPTION
As this module is transpiled to javascript **before** publishing it tonpm it doesn’t make sense to bundle the coffee-script dependency with it.
